### PR TITLE
Display partners when JS is not available

### DIFF
--- a/static/js/find-a-partner.js
+++ b/static/js/find-a-partner.js
@@ -161,10 +161,8 @@
   }
 
   function revealSearch() {
-    var removeSearch = document.querySelector(
-      ".p-find-a-partner.u-hide"
-    );
-    removeSearch.classList.remove("u-hide");
+    var searchForm = document.querySelector(".col-4.p-card.u-hide");
+    searchForm.classList.remove("u-hide");
   }
 
   init();

--- a/templates/find-a-partner/index.html
+++ b/templates/find-a-partner/index.html
@@ -17,7 +17,7 @@
 
 <section class="p-strip is-bordered">
   <div class="row">
-    <div class="col-4 p-card">
+    <div class="col-4 p-card u-hide">
       <form class="p-search-box">
           <input class="p-search-box__input p-find-a-partner__search-input" name="search" id="search" placeholder="Search" required="" type="search">
           <button type="reset" class="p-search-box__reset u-no-margin--right" alt="reset"><i class="p-icon--close"></i></button>
@@ -43,7 +43,7 @@
       </aside>
     </div>
     <div class="col-8">
-      <div id="results" class="p-find-a-partner u-hide">
+      <div id="results" class="p-find-a-partner">
         <div class="p-notification p-find-a-partner__no-results u-hide">
           <p class="p-notification__response">
           Sorry, no partners matches found.<br />


### PR DESCRIPTION
## Done

- Display partners when JS is not available

## QA

1. Download this branch
2. `./run` the site
3. Go to [/find-a-partner](http://0.0.0.0:8003/find-a-partner)
4. Disable JS on the website and check if the partners are displayed
5. Make sure the functionality of the website has not changed when you have JS enabled

## Issue / Card

Fixes #179 
