### PR TITLE
Prevent search bots from indexing thank-you page

### DIFF
--- a/templates/thank-you.html
+++ b/templates/thank-you.html
@@ -1,4 +1,7 @@
 {% extends "templates/base_index.html" %}
+
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+
 {% block title %}Thank you | {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Fixes #190

## QA

`./run`, go to `/thank-you`, check you see `<meta name="robots" content="noindex" />`.