### PR TITLE
Removes Google+ link, corrects bug-reporting link

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -19,9 +19,6 @@
             <a href="https://twitter.com/Ubuntu" title="@ubuntu on Twitter"><i class="p-icon--twitter">@ubuntu on Twitter</i></a>
           </li>
           <li class="p-inline-list__item">
-            <a href="https://plus.google.com/+Ubuntu/posts" title="Ubuntu on Google+"><i class="p-icon--google">Ubuntu on Google+</i></a>
-          </li>
-          <li class="p-inline-list__item">
             <a href="https://www.facebook.com/ubuntulinux?fref=ts" title="Ubuntu on Facebook"><i class="p-icon--facebook">Ubuntu on Facebook</i></a>
           </li>
           <li class="p-inline-list__item">
@@ -47,7 +44,7 @@
     <nav class="p-footer__nav">
       <ul class="p-footer__links">
         <li class="p-footer__item"><a class="p-footer__link" href="https://www.ubuntu.com/legal">Legal information</a></li>
-        <li class="p-footer__item"><a class="p-footer__link" href="https://github.com/canonical-websites/partners.ubuntu.com/issues/new" id="report-a-bug">Report a bug on this site</a></li>
+        <li class="p-footer__item"><a class="p-footer__link" href="https://github.com/canonical-web-and-design/partners.ubuntu.com/issues/new" id="report-a-bug">Report a bug on this site</a></li>
       </ul>
     </nav>
     <span class="u-off-screen"><a href="#">Go to the top of the page</a></span>


### PR DESCRIPTION
## Done

- Removed the Google+ footer link, which is a 404, matching ubuntu.com
- Updated the report-a-bug link

## QA

1. Download this branch
2. `./run` the site
3. Go to http://0.0.0.0:8003/
4. Observe that there is no longer a Google+ button in the footer

## Issue / Card

None, drive-by while investigating IA for OEM pages