### PR TITLE
Redirect /dell to ubuntu.com/dell

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -3,3 +3,4 @@ amazon-web-services-llc/?: /aws
 programmes/phone/?: /
 hp/?: /hewlett-packard-enterprise
 programmes/openstack/?: /programmes
+dell/?: "https://ubuntu.com/dell"


### PR DESCRIPTION
## Done

- Redirect /dell to ubuntu.com/dell

## QA

1. Download this branch
2. `./run` the site
3. Go to http://0.0.0.0:8003/dell
4. See that you are redirected to ubuntu.com/dell

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/6010

