### PR TITLE
Downgrade whitenoise to v4.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ django-yaml-redirects==0.5.4
 django-markdown-deux==1.0.5
 django-template-finder-view==0.3
 django-openid-auth==0.15
-whitenoise==5.0.1
+whitenoise==4.1.4


### PR DESCRIPTION
## Done

- Downgrade whitenoise to v4.1.4

## QA

1. Download this branch
2. `./run` the site
3. Go to http://0.0.0.0:8003/

## Issue / Card

Version 4.1.4 is the last one with support for Python 2
