### PR TITLE
Add marketing opt-in checkbox to form

### DIFF
--- a/templates/request-login.html
+++ b/templates/request-login.html
@@ -74,8 +74,8 @@
             </li>
 
             <li>
-              <input class="mktoField" value="yes" id="partner_newsletter__c" name="partner_newsletter__c" type="checkbox">
-              <label  class="mktoLabel" for="partner_newsletter__c">I agree to receive information about Canonical’s products and services.</label>
+              <input name="Partner_newsletter__c" id="Partner_newsletter__c" type="checkbox" value="yes" class="mktoField">
+              <label  class="mktoLabel" for="Partner_newsletter__c">I agree to receive information about Canonical’s products and services.</label>
             </li>
 
             <li  class="p-list__item mktField">

--- a/templates/request-login.html
+++ b/templates/request-login.html
@@ -73,6 +73,11 @@
               <input required  id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" >
             </li>
 
+            <li>
+              <input class="mktoField" value="yes" id="partner_newsletter__c" name="partner_newsletter__c" type="checkbox">
+              <label  class="mktoLabel" for="partner_newsletter__c">I agree to receive information about Canonical’s products and services.</label>
+            </li>
+
             <li  class="p-list__item mktField">
               <button type="submit" class="mktoButton">Submit</button>
               <input type="hidden" name="formid" class="mktoField " value="3339">


### PR DESCRIPTION
## Done

Added an opt-in field to the contact form

## QA

1. Download this branch
2. `./run` the site
3. Go to http://0.0.0.0:8003/request-login
4. see that the form now has the opt-in form


Fixes https://github.com/canonical-web-and-design/web-squad/issues/2484