### PR TITLE
Update django to v1.11.29

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 setuptools==50.3.2
 talisker[gunicorn]==0.19.0
-Django==1.11
+Django==1.11.29
 django-preserialize==1.2.1
 psycopg2-binary==2.8.6
 dj-database-url==0.5.0


### PR DESCRIPTION
## Done

- Update django to v1.11.29

## QA

Previously the site was not working with Docker:
1. DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag test .
2. docker run -ti -p 8003:80 --env SECRET_KEY=insecure_secret_key --env-file .env test
3. Go to http://0.0.0.0:8003/
