### PR TITLE
Partners needs 512Mi to run

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1,6 +1,8 @@
 domain: partners.ubuntu.com
 image: prod-comms.docker-registry.canonical.com/partners.ubuntu.com
 
+memoryLimit: 512Mi
+
 production:
   replicas: 5
   env:


### PR DESCRIPTION
## Done

- 512Mi seems required to run partners.ubuntu.com
- It seems it was overwritten recently
- We already faced that issue, see: https://github.com/canonical-web-and-design/partners.ubuntu.com/pull/254

## QA

1. Download this branch
2. `snap install konf`
3. `konf production konf/site.yaml`
4. Make sure the output has: 

```
          resources:
            limits:
              memory: 512Mi
```

## Issue / Card

Fixes https://github.com/canonical-web-and-design/partners.ubuntu.com/issues/266