### PR TITLE
Use team renovate config

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -5,7 +5,9 @@ from django.template import loader
 from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
 
-from django_yaml_redirects import load_redirects
+from canonicalwebteam.yaml_responses.django_helpers import (
+    create_redirect_views,
+)
 
 from cms.views import (
     partners_json_view,
@@ -25,7 +27,7 @@ def handler500(request):
     return HttpResponseServerError(t.render({}))
 
 
-urlpatterns = load_redirects()
+urlpatterns = create_redirect_views()
 
 urlpatterns += [
     url(r"^openid/", include("django_openid_auth.urls")),

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,5 @@
 {
   "extends": [
-    "config:base",
-    "schedule:monthly",
-    "group:all"
-  ],
-  "packageRules": [
-    {
-      "depTypeList": ["devDependencies"],
-      "extends": [":automergeMinor"]
-    }
+    "github>canonical-web-and-design/renovate-websites"
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ psycopg2-binary==2.8.6
 dj-database-url==0.5.0
 python-openid==2.2.5
 django-static-root-finder==0.3.1
-django-yaml-redirects==0.5.4
+canonicalwebteam.yaml-responses==1.2.0
 django-markdown-deux==1.0.5
 django-openid-auth==0.16
 whitenoise==5.2.0


### PR DESCRIPTION
## Done

- Update renovate config to use team settings, and disable the Dependency Dashboard

## QA

- Check the code, it should match projects that are successfully using the team config i.e. [ubuntu.com](https://github.com/canonical-web-and-design/ubuntu.com/blob/main/renovate.json)

## Issue / Card

Fixes #269 
